### PR TITLE
Fix rendering of h[1-6] titles in text post-processing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,17 @@ and the wikitext will be rendered as HTML in the article.htm file.
 
 Other ways might be implemented in the future.
 
+Unit tests
+----------
 
+Install nose and run:
+
+::
+
+ cd /PATH/TO/mediawiki-parser/
+ ln -s ../mediawiki-parser/ mediawiki_parser
+ export PYTHONPATH=/PATH/TO/mediawiki-parser/:/PATH/TO/pijnu/
+ nosetests tests
 
 How to use in a program
 =======================

--- a/tests/test_text_postprocessor.py
+++ b/tests/test_text_postprocessor.py
@@ -4,8 +4,28 @@ from mediawiki_parser.tests import PostprocessorTestCase
 
 
 class TextBackendTests(PostprocessorTestCase):
+    def test_simple_title(self):
+        source = '= A title =\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, 'wikitext', {}, 'text')
+
     def test_simple_title2(self):
         source = '== A title ==\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, 'wikitext', {}, 'text')
+
+    def test_simple_title3(self):
+        source = '=== A title ===\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, 'wikitext', {}, 'text')
+
+    def test_simple_title4(self):
+        source = '==== A title ====\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, 'wikitext', {}, 'text')
+
+    def test_simple_title5(self):
+        source = '==== A title ====\n'
         result = ' A title \n'
         self.parsed_equal_string(source, result, 'wikitext', {}, 'text')
 
@@ -13,6 +33,36 @@ class TextBackendTests(PostprocessorTestCase):
         source = '====== Test! ======\n'
         result = ' Test! \n'
         self.parsed_equal_string(source, result, 'wikitext', {}, 'text')
+
+    def test_simple_title_without_method(self):
+        source = '= A title =\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, None, {}, 'text')
+
+    def test_simple_title2_without_method(self):
+        source = '== A title ==\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, None, {}, 'text')
+
+    def test_simple_title3_without_method(self):
+        source = '=== A title ===\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, None, {}, 'text')
+
+    def test_simple_title4_without_method(self):
+        source = '==== A title ====\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, None, {}, 'text')
+
+    def test_simple_title5_without_method(self):
+        source = '==== A title ====\n'
+        result = ' A title \n'
+        self.parsed_equal_string(source, result, None, {}, 'text')
+
+    def test_simple_title6_without_method(self):
+        source = '====== Test! ======\n'
+        result = ' Test! \n'
+        self.parsed_equal_string(source, result, None, {}, 'text')
 
     def test_simple_allowed_open_tag(self):
         source = 'a<p>test'

--- a/text.py
+++ b/text.py
@@ -13,22 +13,22 @@ def toolset():
                     'br': render_tag_br}
 
     def render_title1(node):
-        node.value += '\n'
+        node.value = '%s\n' % node.leaf()
 
     def render_title2(node):
-        node.value += '\n'
+        node.value = '%s\n' % node.leaf()
 
     def render_title3(node):
-        node.value += '\n'
+        node.value = '%s\n' % node.leaf()
 
     def render_title4(node):
-        node.value += '\n'
+        node.value = '%s\n' % node.leaf()
 
     def render_title5(node):
-        node.value += '\n'
+        node.value = '%s\n' % node.leaf()
 
     def render_title6(node):
-        node.value += '\n'
+        node.value = '%s\n' % node.leaf()
 
     def render_raw_text(node):
         pass
@@ -41,7 +41,6 @@ def toolset():
 
     def render_body(node):
         tags = {'bold': '*', 'bold_close': '*', 'italic': '_', 'italic_close': '_'}
-        print node
         node.value = apostrophes.parse(node.leaf(), tags)
 
     def render_entity(node):


### PR DESCRIPTION
This fixes a bug with the access pattern described in the README under "Example for text" when given the wikitext.txt as source.

It would fail with:

  File "/tmp/pijnu/library/node.py", line 257, in <genexpr>
    value = ''.join(item.leaf() for item in self.value)
AttributeError: 'str' object has no attribute 'leaf'
